### PR TITLE
fix(hub): log processing block at debug instead of info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `hub.ForkableHub` now logs `processing block` at `Debug` instead of `Info`; on flash-block chains the line fired several times per block.
+- `hub.ForkableHub` logs `processing block` at `Debug`, except for one line every 10 seconds kept at `Info` to show progress; on flash-block chains the line fired several times per block.
 - A cursor above head is now retryable, in case we are lagging behind and another instance is already serving that block.
 - `ForkableHub` bootstrap now rounds its lowest kept block down to the configured merged-blocks bundle size instead of a hardcoded `100`.
 - `ForkableHub` now downloads one-block files 32 at a time, still processing them in block order, both when bootstrapping and when filling the gap before a live block it cannot link. It used to download them one at a time, which was too slow on fast chains with remote storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `hub.ForkableHub` now logs `processing block` at `Debug` instead of `Info`; on flash-block chains the line fired several times per block.
 - A cursor above head is now retryable, in case we are lagging behind and another instance is already serving that block.
 - `ForkableHub` bootstrap now rounds its lowest kept block down to the configured merged-blocks bundle size instead of a hardcoded `100`.
 - `ForkableHub` now downloads one-block files 32 at a time, still processing them in block order, both when bootstrapping and when filling the gap before a live block it cannot link. It used to download them one at a time, which was too slow on fast chains with remote storage.

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -377,7 +377,7 @@ func (h *ForkableHub) ProcessBlock(blk *pbbstream.Block, obj any) error {
 		return nil // we don't get ready with partial blocks...
 	}
 
-	h.logger.Info("processing block", zap.Uint64("block_number", blk.Number), zap.String("block_Id", blk.Id), zap.Uint64("block_lib", blk.LibNum), zap.Duration("age", time.Since(blk.Time())))
+	h.logger.Debug("processing block", zap.Uint64("block_number", blk.Number), zap.String("block_Id", blk.Id), zap.Uint64("block_lib", blk.LibNum), zap.Duration("age", time.Since(blk.Time())))
 
 	ctx := context.Background()
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -31,6 +31,7 @@ import (
 	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
 	"github.com/streamingfast/shutter"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // ForkableHub gives you block Sources for blocks close to head
@@ -57,9 +58,16 @@ type ForkableHub struct {
 	consecutiveUnlinkableBlocks    int
 
 	oneBlockDownloadConcurrency int
+
+	lastProgressLog time.Time
 }
 
 const defaultOneBlockDownloadConcurrency = 32
+
+// progressLogInterval is how often "processing block" is logged at Info. The hub sees
+// every block of every live source, including each partial of a flash block, which is far
+// too many to log individually; one line per interval is enough to show it is progressing.
+const progressLogInterval = 10 * time.Second
 
 func NewForkableHub(liveSourceFactory bstream.SourceFactory, keepFinalBlocks int, oneBlocksStore dstore.Store, extraForkableOptions ...forkable.Option) *ForkableHub {
 	return newForkableHub(liveSourceFactory, keepFinalBlocks, oneBlocksStore, nil, extraForkableOptions...)
@@ -377,7 +385,14 @@ func (h *ForkableHub) ProcessBlock(blk *pbbstream.Block, obj any) error {
 		return nil // we don't get ready with partial blocks...
 	}
 
-	h.logger.Debug("processing block", zap.Uint64("block_number", blk.Number), zap.String("block_Id", blk.Id), zap.Uint64("block_lib", blk.LibNum), zap.Duration("age", time.Since(blk.Time())))
+	progressLevel := zapcore.DebugLevel
+	if time.Since(h.lastProgressLog) >= progressLogInterval {
+		h.lastProgressLog = time.Now()
+		progressLevel = zapcore.InfoLevel
+	}
+	if ce := h.logger.Check(progressLevel, "processing block"); ce != nil {
+		ce.Write(zap.Uint64("block_number", blk.Number), zap.String("block_Id", blk.Id), zap.Uint64("block_lib", blk.LibNum), zap.Duration("age", time.Since(blk.Time())))
+	}
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This one log line accounted for roughly 27 GB/day, about 40% of the dfuseio-global project's log ingestion. `hub.ForkableHub.ProcessBlock` logs it once per block, including partial blocks, so on a flash-block chain a relayer emitted around 80 of these lines per block. The `DLOG='.*=info,bstream=warn'` spec used in deployments no longer mutes it since firehose-core passes the relayer/firehose logger through `hub.WithLogger`, so the line stopped matching the `bstream=warn` filter. Dropping it to `Debug` fixes the ingestion cost without deploy changes.

Note: `TestFileSource_Run` is flaky (unsynchronized `preProcessCount` read in `filesource_test.go`), unrelated to this change.